### PR TITLE
fix(README.md): Fix typo in README configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ XClock.Clock.minuteColor: #5060cc
 XClock.Clock.secondColor: #7080ff
 XClock.Clock.majorColor: #cc6050
 XClock.Clock.minorColor: #5060cc
-XClock.Clock.circular: #true
+XClock.Clock.circular: true
 ```
 
 Load the X resources and start xclock:


### PR DESCRIPTION
Background:
When using the example settings from `README.md`, `xclock` outputs: `Warning: Cannot convert string "#true" to type Boolean`

Expected changes:
 - Fix the typo in the settings so no warning is issued.